### PR TITLE
Null argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1 14 Mar 2021
+* Fix for incorrect HTTP response handling on iOS
+
 ## 0.6.0 28 Feb 2021
 * Fix losing connection after the hot restart
 

--- a/example/ios/AppSpectorPluginTestPlan.xctestplan
+++ b/example/ios/AppSpectorPluginTestPlan.xctestplan
@@ -13,7 +13,15 @@
     }
   ],
   "defaultOptions" : {
-
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Pods\/Pods.xcodeproj",
+          "identifier" : "8EE4B296639698DC467B95DEA0D6285A",
+          "name" : "appspector"
+        }
+      ]
+    }
   },
   "testTargets" : [
     {

--- a/example/ios/AppSpectorPluginTests/ASPluginEventsHandlerTests.m
+++ b/example/ios/AppSpectorPluginTests/ASPluginEventsHandlerTests.m
@@ -45,4 +45,19 @@
     [self waitForExpectations:@[e] timeout:1.1];
 }
 
+- (void)testHandlerSendsLogEvent {
+    XCTestExpectation *e = [self expectationWithDescription:@""];
+    OCMStub([self.callValidatorMock eventMethodSupported:[OCMArg any]]).andReturn(YES);
+    OCMStub([self.callValidatorMock argumentsValid:[OCMArg any] call:[OCMArg any] error:[OCMArg anyObjectRef]]).andReturn(YES);
+    
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kLogEventMethodName arguments:@{ @"level" : @"warning",
+                                                                                                           @"message" : @"test" }];
+    [self.handler handleMethodCall:call result:^(id result) {
+        expect(result).toNot.beNil();
+        [e fulfill];
+    }];
+    
+    [self waitForExpectations:@[e] timeout:1.1];
+}
+
 @end

--- a/example/ios/AppSpectorPluginTests/ASPluginEventsHandlerTests.m
+++ b/example/ios/AppSpectorPluginTests/ASPluginEventsHandlerTests.m
@@ -32,41 +32,162 @@
     self.handler = nil;
 }
 
-- (void)testHandlerReturnsErrorForInvalidCall {
+#pragma mark - Invalid calls -
+
+- (void)testHandlerReturnsErrorForInvalidCallName {
     XCTestExpectation *e = [self expectationWithDescription:@""];
     OCMStub([self.callValidatorMock eventMethodSupported:[OCMArg any]]).andReturn(NO);
     
     FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"foo" arguments:@{}];
     [self.handler handleMethodCall:call result:^(id result) {
-        expect(result).toNot.beNil();
+        expect(result).to.equal(FlutterMethodNotImplemented);
         [e fulfill];
     }];
     
     [self waitForExpectations:@[e] timeout:1.1];
 }
 
-- (void)testHandlerSendsLogEvent {
+- (void)testHandlerReturnsErrorForInvalidCallArgs {
     XCTestExpectation *e = [self expectationWithDescription:@""];
+    
     OCMStub([self.callValidatorMock eventMethodSupported:[OCMArg any]]).andReturn(YES);
-    OCMStub([self.callValidatorMock argumentsValid:[OCMArg any] call:[OCMArg any] error:[OCMArg anyObjectRef]]).andReturn(YES);
     
-    NSDictionary *payload = @{ @"level" : @"warning",
-                               @"message" : @"test" };
+    NSString *errorDescription = @"foo_error";
+    NSError *error = OCMClassMock([NSError class]);
+    OCMStub([error localizedDescription]).andReturn(errorDescription);
+    OCMStub([self.callValidatorMock argumentsValid:[OCMArg any] call:[OCMArg any] error:[OCMArg setTo:error]]).andReturn(NO);
     
-    id sdkMock = [OCMockObject mockForClass:[AppSpector class]];
-    OCMExpect([sdkMock sendEvent:[OCMArg checkWithBlock:^BOOL(ASExternalEvent *event) {
-        return [event.monitorID isEqualToString:AS_LOG_MONITOR] &&
-                [event.eventID isEqualToString:@"log"] &&
-                [event.payload isEqualToDictionary:payload];
-    }]]);
-    
-    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kLogEventMethodName arguments:payload];
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"foo" arguments:@{}];
     [self.handler handleMethodCall:call result:^(id result) {
-        expect(result).toNot.beNil();
+        expect(result).to.equal(errorDescription);
         [e fulfill];
     }];
     
-    OCMVerifyAll(sdkMock);
+    [self waitForExpectations:@[e] timeout:1.1];
+}
+
+
+- (void)testHandlerSendsLogEvent {
+    NSDictionary *payload = @{ @"level" : @"warning",
+                               @"message" : @"test" };
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kLogEventMethodName arguments:payload];
+    ASExternalEvent *expectedEvent = [[ASExternalEvent alloc] initWithMonitorID:AS_LOG_MONITOR eventID:@"log" payload:payload];
+    
+    [self performCall:call andValidateEvent:expectedEvent];
+}
+
+- (void)testHandlerSendsHTTPRequestEvent {
+    NSData *rawData = [@"DESDBEEF" dataUsingEncoding:NSUTF8StringEncoding];
+    FlutterStandardTypedData *flutterData = [FlutterStandardTypedData typedDataWithBytes:rawData];
+    NSString *UUID = [NSUUID UUID].UUIDString;
+    
+    NSDictionary *args = @{ @"uid"          : UUID,
+                            @"url"           : @"http://google.com",
+                            @"method"        : @"GET",
+                            @"body"          : flutterData,
+                            @"headers"       : @{} };
+    
+    NSDictionary *payload = @{ @"uuid"          : UUID,
+                               @"url"           : @"http://google.com",
+                               @"method"        : @"GET",
+                               @"body"          : rawData,
+                               @"hasLargeBody"  : @(NO),
+                               @"headers"       : @{} };
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kHTTPRequestMethodName arguments:args];
+    ASExternalEvent *expectedEvent = [[ASExternalEvent alloc] initWithMonitorID:AS_HTTP_MONITOR eventID:@"http-request" payload:payload];
+    
+    [self performCall:call andValidateEvent:expectedEvent];
+}
+
+/// If handler gets event with invalid body it sould substitute it with emty data
+- (void)testHandlerSendsHTTPRequestEventWithoutBody {
+    NSString *UUID = [NSUUID UUID].UUIDString;
+    NSDictionary *args = @{ @"uid"          : UUID,
+                            @"url"           : @"http://google.com",
+                            @"method"        : @"GET",
+                            @"body"          : [NSObject new],
+                            @"headers"       : @{} };
+    
+    NSDictionary *payload = @{ @"uuid"          : UUID,
+                               @"url"           : @"http://google.com",
+                               @"method"        : @"GET",
+                               @"body"          : [NSData data],
+                               @"hasLargeBody"  : @(NO),
+                               @"headers"       : @{} };
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kHTTPRequestMethodName arguments:args];
+    ASExternalEvent *expectedEvent = [[ASExternalEvent alloc] initWithMonitorID:AS_HTTP_MONITOR eventID:@"http-request" payload:payload];
+    
+    [self performCall:call andValidateEvent:expectedEvent];
+}
+
+- (void)testHandlerSendsHTTPResponseEvent {
+    NSData *rawData = [@"DESDBEEF" dataUsingEncoding:NSUTF8StringEncoding];
+    FlutterStandardTypedData *flutterData = [FlutterStandardTypedData typedDataWithBytes:rawData];
+    NSString *UUID = [NSUUID UUID].UUIDString;
+    
+    NSDictionary *args = @{ @"uid"          : UUID,
+                            @"code"         : @(200),
+                            @"body"         : flutterData,
+                            @"headers"      : @{},
+                            @"tookMs"       : @(100) };
+    
+    NSDictionary *payload = @{ @"uuid"              : UUID,
+                               @"statusCode"        : @(200),
+                               @"body"              : rawData,
+                               @"hasLargeBody"      : @(NO),
+                               @"headers"           : @{},
+                               @"responseDuration"  : @(100),
+                               @"error"             : @"" };
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kHTTPResponseMethodName arguments:args];
+    ASExternalEvent *expectedEvent = [[ASExternalEvent alloc] initWithMonitorID:AS_HTTP_MONITOR eventID:@"http-response" payload:payload];
+    
+    [self performCall:call andValidateEvent:expectedEvent];
+}
+
+/// If handler gets event with invalid body it sould substitute it with emty data
+- (void)testHandlerSendsHTTPResponseEventWithoutBody {
+    NSString *UUID = [NSUUID UUID].UUIDString;
+    NSDictionary *args = @{ @"uid"          : UUID,
+                            @"code"         : @(200),
+                            @"body"         : [NSObject new],
+                            @"headers"      : @{},
+                            @"tookMs"       : @(100) };
+    
+    NSDictionary *payload = @{ @"uuid"              : UUID,
+                               @"statusCode"        : @(200),
+                               @"body"              : [NSData data],
+                               @"hasLargeBody"      : @(NO),
+                               @"headers"           : @{},
+                               @"responseDuration"  : @(100),
+                               @"error"             : @"" };
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:kHTTPResponseMethodName arguments:args];
+    ASExternalEvent *expectedEvent = [[ASExternalEvent alloc] initWithMonitorID:AS_HTTP_MONITOR eventID:@"http-response" payload:payload];
+    
+    [self performCall:call andValidateEvent:expectedEvent];
+}
+
+
+#pragma mark - Event sender
+
+- (void)performCall:(FlutterMethodCall *)call andValidateEvent:(ASExternalEvent *)expectedEvent {
+    XCTestExpectation *e = [self expectationWithDescription:@""];
+    
+    OCMStub([self.callValidatorMock eventMethodSupported:[OCMArg any]]).andReturn(YES);
+    OCMStub([self.callValidatorMock argumentsValid:[OCMArg any] call:[OCMArg any] error:[OCMArg anyObjectRef]]).andReturn(YES);
+    
+    id sdkMock = [OCMockObject mockForClass:[AppSpector class]];
+    OCMExpect([sdkMock sendEvent:[OCMArg checkWithBlock:^BOOL(ASExternalEvent *event) {
+        expect(event.monitorID).to.equal(expectedEvent.monitorID);
+        expect(event.eventID).to.equal(expectedEvent.eventID);
+        expect(event.payload).to.equal(expectedEvent.payload);
+        return YES;
+    }]]);
+    
+    [self.handler handleMethodCall:call result:^(id result) {
+        expect(result).toNot.beNil();
+        OCMVerifyAll(sdkMock);
+        [e fulfill];
+    }];
     
     [self waitForExpectations:@[e] timeout:1.1];
 }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.appspector.flutter.appspectorPluginExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "AppSpector development wildcard";
+				PROVISIONING_PROFILE_SPECIFIER = "AppSpector wildcard development";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -751,7 +751,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.appspector.flutter.appspectorPluginExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "AppSpector development wildcard";
+				PROVISIONING_PROFILE_SPECIFIER = "AppSpector wildcard development";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -761,7 +761,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = EEJA65ZWYD;
@@ -780,7 +780,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.appspector.flutter.appspectorPluginExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "AppSpector development wildcard";
+				PROVISIONING_PROFILE_SPECIFIER = "AppSpector Distribution";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/Classes/ASPluginEventsHandler.m
+++ b/ios/Classes/ASPluginEventsHandler.m
@@ -41,34 +41,37 @@
         }
         
         // Handle call
+        // HTTP monitor
         if ([call.method isEqualToString:kHTTPRequestMethodName]) {
-            [self handleRequestCall:call.arguments result:result];
+            [self handleHTTPRequestCall:call.arguments result:result];
         }
         
         if ([call.method isEqualToString:kHTTPResponseMethodName]) {
-            [self handleResponseCall:call.arguments result:result];
+            [self handleHTTPResponseCall:call.arguments result:result];
         }
         
+        // Logs monitor
         if ([call.method isEqualToString:kLogEventMethodName]) {
             [self handleLogEventCall:call.arguments result:result];
         }
+    } else {
+        result(FlutterMethodNotImplemented);
     }
-      
-    result(FlutterMethodNotImplemented);
 }
 
 #pragma mark - Call handlers -
+#pragma mark - HTTP monitor
 
-- (void)handleRequestCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
+- (void)handleHTTPRequestCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
     // Build event payload
-    NSData *body = [NSData data];
-    if ([arguments[@"body"] isKindOfClass:[FlutterStandardTypedData class]]) {
-        body = [(FlutterStandardTypedData *)arguments[@"body"] data];
-    }
+//    NSData *body = [NSData data];
+//    if ([arguments[@"body"] isKindOfClass:[FlutterStandardTypedData class]]) {
+//        body = [(FlutterStandardTypedData *)arguments[@"body"] data];
+//    }
     NSDictionary *payload = @{ @"uuid"          : arguments[@"uid"],
                                @"url"           : arguments[@"url"],
                                @"method"        : arguments[@"method"],
-                               @"body"          : body,
+                               @"body"          : [self unwrapData:arguments[@"body"]],
                                @"hasLargeBody"  : @(NO),
                                @"headers"       : arguments[@"headers"] };
     
@@ -79,11 +82,15 @@
     result(@"Ok");
 }
 
-- (void)handleResponseCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
+- (void)handleHTTPResponseCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
     // Build event payload
+//    NSData *body = [NSData data];
+//    if ([arguments[@"body"] isKindOfClass:[FlutterStandardTypedData class]]) {
+//        body = [(FlutterStandardTypedData *)arguments[@"body"] data];
+//    }
     NSDictionary *payload = @{ @"uuid"              : arguments[@"uid"],
                                @"statusCode"        : arguments[@"code"],
-                               @"body"              : [(FlutterStandardTypedData *)arguments[@"body"] data],
+                               @"body"              : [self unwrapData:arguments[@"body"]],
                                @"hasLargeBody"      : @(NO),
                                @"headers"           : arguments[@"headers"],
                                @"responseDuration"  : arguments[@"tookMs"],
@@ -95,6 +102,8 @@
     
     result(@"Ok");
 }
+
+#pragma mark - Logs monitor
 
 - (void)handleLogEventCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
     // Build event payload
@@ -108,5 +117,15 @@
     result(@"Ok");
 }
 
+#pragma mark - Tools
+
+- (NSData *)unwrapData:(id)flutterData {
+    NSData *unwrappedData = [NSData data];
+    if ([flutterData isKindOfClass:[FlutterStandardTypedData class]]) {
+        unwrappedData = [(FlutterStandardTypedData *)flutterData data];
+    }
+    
+    return unwrappedData;
+}
 
 @end

--- a/ios/Classes/ASPluginEventsHandler.m
+++ b/ios/Classes/ASPluginEventsHandler.m
@@ -64,10 +64,6 @@
 
 - (void)handleHTTPRequestCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
     // Build event payload
-//    NSData *body = [NSData data];
-//    if ([arguments[@"body"] isKindOfClass:[FlutterStandardTypedData class]]) {
-//        body = [(FlutterStandardTypedData *)arguments[@"body"] data];
-//    }
     NSDictionary *payload = @{ @"uuid"          : arguments[@"uid"],
                                @"url"           : arguments[@"url"],
                                @"method"        : arguments[@"method"],
@@ -84,10 +80,6 @@
 
 - (void)handleHTTPResponseCall:(ASPluginMethodArgumentsList *)arguments result:(FlutterResult)result {
     // Build event payload
-//    NSData *body = [NSData data];
-//    if ([arguments[@"body"] isKindOfClass:[FlutterStandardTypedData class]]) {
-//        body = [(FlutterStandardTypedData *)arguments[@"body"] data];
-//    }
     NSDictionary *payload = @{ @"uuid"              : arguments[@"uid"],
                                @"statusCode"        : arguments[@"code"],
                                @"body"              : [self unwrapData:arguments[@"body"]],

--- a/ios/appspector.podspec
+++ b/ios/appspector.podspec
@@ -14,6 +14,6 @@ AppSpector SDK
   s.dependency 'Flutter'
   s.dependency 'AppSpectorSDK'
 
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
 end
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appspector
 description: A plugin that integrate AppSpector to your Flutter project.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/appspector/flutter-plugin
 
 environment:


### PR DESCRIPTION
Adds safe unwrapping of the `FlutterStandardTypedData` argument passed to call handler.
Falls back to empty NSData if null passed.